### PR TITLE
docs: Add note that cborm.logParams requires modern CBORM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,7 +150,7 @@ moduleSettings = {
 		cborm : {
 			enabled   : true,
 			expanded  : false,
-			// Log the binding parameters
+			// Log the binding parameters (requires CBORM 3.2.0+)
 			logParams : true
 		},
 		// Async Manager Reporting
@@ -372,7 +372,7 @@ We have a dedicated panel in the debugger that will track all criteria queries a
 cborm : {
 	enabled   : true,
 	expanded  : false,
-	// Log the binding parameters
+	// Log the binding parameters (requires CBORM 3.2.0+)
 	logParams : true
 }
 ```


### PR DESCRIPTION
CBDebugger breaks on logCriteriaQuery if the app is using a CBORM version older than 3.2.0.

The workaround is setting `moduleSettings.cbDebugger.cborm.logParams` to false:

```
cbDebugger : {
    enabled : true,
    ...
    cborm : {
        enabled   : true,
        expanded  : false,
        // Log the binding parameters
        logParams : false
    }
}
```