### PR TITLE
Updated install requirements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,10 @@ Apache License, Version 2.0.
 - ColdFusion 2016+
 - ColdBox 6+
 
+## Debugger Requirements
+
+- If you're using Adobe Coldfusion 2021: `orm` package 
+
 # Instructions
 
 Just drop into your **modules** folder or use CommandBox to install

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,8 @@ Apache License, Version 2.0.
 
 ## Debugger Requirements
 
-- If you're using Adobe Coldfusion 2021: `orm` package 
+- Hibernate extension (on Lucee)
+- ORM package (on ACF 2021)
 
 # Instructions
 


### PR DESCRIPTION
@michaelborn and I have found out that cbdebugger has some requirements not mentioned in the docs. 
hibernate ext for lucee, and orm package for acf 2021.  