### PR TITLE
Pass the correct argument to stopCBTimer

### DIFF
--- a/helpers/Mixins.cfm
+++ b/helpers/Mixins.cfm
@@ -39,7 +39,7 @@
 	 * @labelHash The timer label hash to stop
 	 */
 	function stopCBTimer( required labelHash ){
-		return variables.wirebox.getInstance( "Timer@cbdebugger" ).stop( arguments.label );
+		return variables.wirebox.getInstance( "Timer@cbdebugger" ).stop( arguments.labelHash );
 	}
 
 	/**


### PR DESCRIPTION
stopCBTimer is expecting labelHash but is using arguments.label when it needs to use arguments.labelHash